### PR TITLE
Renaming contiv-vpp to pteropus.io

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -37,8 +37,8 @@ theme = "airspace-hugo"
 #  points to slider.html under themes/../partials
   [params.slider]
     enable = true
-    title = "Contiv VPP"
-    subtitle = "Contiv VPP is a Kubernetes CNI plugin that employs a programmable CNF vSwitch based an FD.io/VPP offering feature-rich, high-performance cloud native networking and services."
+    title = "Pteropus.io"
+    subtitle = "Pteropus.io is a Kubernetes CNI plugin that employs a programmable CNF vSwitch based an FD.io/VPP offering feature-rich, high-performance cloud native networking and services."
 
 #  points to wrapper.html under themes/../partials
   [params.wrapper]
@@ -55,7 +55,7 @@ theme = "airspace-hugo"
 # points to feature.html in partials
   [params.feature]
     enable = true
-    title = "Contiv VPP Highlights"
+    title = "Pteropus.io Highlights"
     content = """
 
 * Kubernetes services and policies traffic mapped to the FD.io/VPP data plane
@@ -76,5 +76,5 @@ theme = "airspace-hugo"
 
   [params.call]
     enable = true
-    title = "Contiv VPP"
+    title = "Pteropus.io"
 


### PR DESCRIPTION
Signed-off-by: Kyle Mestery <mestery@mestery.com>